### PR TITLE
Add missing dependency between tasks

### DIFF
--- a/src/main/resources/java.gradle
+++ b/src/main/resources/java.gradle
@@ -67,6 +67,7 @@ if (JavaVersion.current().isJava8Compatible()) {
 }
 
 compileJava.dependsOn 'googleJavaFormat'
+verifyJavaFormat.dependsOn 'googleJavaFormat'
 
 spotbugs {
  ignoreFailures = true

--- a/src/main/resources/java.gradle
+++ b/src/main/resources/java.gradle
@@ -67,7 +67,7 @@ if (JavaVersion.current().isJava8Compatible()) {
 }
 
 compileJava.dependsOn 'googleJavaFormat'
-verifyJavaFormat.dependsOn 'googleJavaFormat'
+verifyGoogleJavaFormat.dependsOn 'googleJavaFormat'
 
 spotbugs {
  ignoreFailures = true


### PR DESCRIPTION
Hello

This commits adds a missing dependency between `verifyGoogleJavaFormat` and
`googleJavaFormat`.

The task `googleJavaFormat` formats source files according to the rules of Google, while the task `verifyGoogleJavaFormat` verifies whether sources files follow the rules of Google.

If `verifyGoogleJavaFormat` runs before `googleJavaFormat`, the build
might fail.

This is an example where the build fails due to an ordering violation.

```
> Task :verifyGoogleJavaFormat FAILED
Caching disabled for task ':verifyGoogleJavaFormat' because:
  Build cache is disabled
Task ':verifyGoogleJavaFormat' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
Begin violations-gradle-plugin:verifyGoogleJavaFormat
/root/violations-gradle-plugin/src/main/java/se/bjurr/violations/gradle/plugin/ViolationsTask.java: verified proper formatting
/root/violations-gradle-plugin/src/main/java/se/bjurr/violations/gradle/plugin/ViolationsGradlePlugin.java: verified proper formatting


The following files are not formatted properly:

/root/violations-gradle-plugin/src/main/java/se/bjurr/violations/gradle/plugin/ViolationsPluginExtension.java
:verifyGoogleJavaFormat (Thread[Execution worker for ':',5,main]) completed. Took 0.536 secs.

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':verifyGoogleJavaFormat'.
> Problems: formatting style violations
```